### PR TITLE
change casing in campaign serializer to match graphql typedef. 

### DIFF
--- a/datasources/campaign.js
+++ b/datasources/campaign.js
@@ -135,7 +135,7 @@ class CampaignAPI extends DataSource {
       serializeCampaign.name = campaign.name;
       serializeCampaign.adminId = campaign.admin_id;
       serializeCampaign.active = campaign.active;
-      serializeCampaign.active_creative_id = campaign.active_creative_id;
+      serializeCampaign.activeCreativeId = campaign.active_creative_id;
       serializeCampaign.createdAt = campaign.createdAt;
       serializeCampaign.updatedAt = campaign.updatedAt;
       if (!campaign.creatives) {


### PR DESCRIPTION
active_creative_id was getting dropped from response