### PR TITLE
Campaigns that do not have an active creative ID set are not render-a…

### DIFF
--- a/datasources/campaign.js
+++ b/datasources/campaign.js
@@ -157,7 +157,7 @@ class CampaignAPI extends DataSource {
         }
       ]
     });
-    const results = campaigns.map(campaign => new Campaign(campaign));
+    const results = campaigns.map(campaign => new Campaign(campaign)).filter(campaign => campaign.activeCreativeId);
 
     return results;
   }


### PR DESCRIPTION
…ble by the mobile client and shouldn't be shown in the list of campaigns.