### PR TITLE
Change name of campaign to experience

### DIFF
--- a/datasources/campaign.js
+++ b/datasources/campaign.js
@@ -60,8 +60,13 @@ class CampaignAPI extends DataSource {
   }
 
   async addCampaign(name, adminId) {
+    if (name === "null"){
+      let maxid = await db["campaign"].max("id");
+      name = `Experience ${++maxid}`;
+    }
     if (name && name.trim() === "")
       throw new UserInputError("Name was not supplied.");
+
 
     const insert = await db["campaign"].create({
       name,


### PR DESCRIPTION
This changes the Campaign to Experience it relies on the campaign being passed as a string with the value of "null". 